### PR TITLE
fix: add missing eqlc parser

### DIFF
--- a/binaryopt.go
+++ b/binaryopt.go
@@ -121,7 +121,7 @@ func Eql(left parser.Expr, right parser.Expr) *BinaryBuilder {
 }
 
 func Eqlc(left parser.Expr, right parser.Expr) *BinaryBuilder {
-	return createBinaryOperation(parser.EQL, left, right)
+	return createBinaryOperation(parser.EQLC, left, right)
 }
 
 func Gte(left parser.Expr, right parser.Expr) *BinaryBuilder {


### PR DESCRIPTION
While working on https://github.com/perses/community-dashboards/pull/122, noticed eqlc parsers missing from builder. 
Also EQL_REGEX|NEQ_REGEX were missing, added as well.
